### PR TITLE
Keywords for data attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ $ mix deps.get
   {"body", nil, [
     {"span", [class: "this-is-a-class\" other classes go here"], "This is a test"},
     {"span", class: "attribute-with-¨˜ˆçø"},
+    {"span", data: "This is a test."},
+    {"span", data: [foo: 1, bar: "This is a test."]},
     {"span", nil, [
       "Hello,",
       "World",
@@ -54,6 +56,8 @@ $ mix deps.get
 # <body>
 #   <span class="this-is-a-class&quot; other classes go here">This is a test</span>
 #   <span class=attribute-with-¨˜ˆçø></span>
+#   <span data="This is a test."></span>
+#   <span data-foo=1 data-bar="This is a test."></span>
 #   <span>
 #     Hello,
 #     World

--- a/lib/html_builder/encoder.ex
+++ b/lib/html_builder/encoder.ex
@@ -200,6 +200,10 @@ defimpl HTMLBuilder.Encoder, for: Tuple do
         [" ", to_string(key)]
       {key, ""} ->
         [" ", to_string(key), "=\"\""]
+      {:data, keywords} when is_list(keywords) ->
+        Enum.map(keywords, fn({key, value}) ->
+          [" ", to_string("data-#{key}"), ?=, encode_attribute_value(value)]
+        end)
       {key, value} ->
         [" ", to_string(key), ?=, encode_attribute_value(value)]
     end)

--- a/lib/html_builder/encoder.ex
+++ b/lib/html_builder/encoder.ex
@@ -223,5 +223,5 @@ defimpl HTMLBuilder.Encoder, for: Tuple do
   end
 
   defp check_quote(character) when character in [" ", "\t", "\r", "\n", "\f", "\0", "\"", "'", "=", ">", "<", "`"], do: true
-  defp check_quote(character), do: false
+  defp check_quote(_character), do: false
 end

--- a/test/html_builder_test.exs
+++ b/test/html_builder_test.exs
@@ -24,6 +24,8 @@ defmodule HTMLBuilderTest do
         {"body", nil, [
           {"span", [class: "this-is-a-class\" other classes go here"], "This is a test"},
           {"span", class: "attribute-with-¨˜ˆçø"},
+          {"span", data: "This is a test."},
+          {"span", data: [foo: 1, bar: "This is a test."]},
           {"span", nil, [
             "Hello,",
             "World",
@@ -48,6 +50,8 @@ defmodule HTMLBuilderTest do
       <body>
         <span class="this-is-a-class&quot; other classes go here">This is a test</span>
         <span class=attribute-with-¨˜ˆçø></span>
+        <span data="This is a test."></span>
+        <span data-foo=1 data-bar="This is a test."></span>
         <span>
           Hello,
           World


### PR DESCRIPTION
The last commit allows us to add a tuple like as

```
{"span", data: [foo: 1, bar: "This is a test."]}
```

to produce an element with custom data attributes:

```
<span data-foo=1 data-bar="This is a test."></span>
```