### PR TITLE
make compiled encoder functions public

### DIFF
--- a/lib/html_builder/encoder.ex
+++ b/lib/html_builder/encoder.ex
@@ -20,22 +20,22 @@ defmodule HTMLBuilder.Pretty do
         []
       end
 
-      defp pretty(options) do
+      def pretty(options) do
         !!Map.get(options, :pretty)
       end
 
-      defp indent(options) do
+      def indent(options) do
         Map.get(options, :indent, @default_indent)
       end
 
-      defp offset(options) do
+      def offset(options) do
         Map.get(options, :offset, @default_offset)
       end
 
-      defp offset(options, value) when value > 0 do
+      def offset(options, value) when value > 0 do
         Map.put(options, :offset, value)
       end
-      defp offset(options, _) do
+      def offset(options, _) do
         Map.put(options, :offset, 0)
       end
 
@@ -49,7 +49,7 @@ defmodule HTMLBuilder.Pretty do
         offset(options, value - 1)
       end
 
-      defp spaces(count) do
+      def spaces(count) do
         :binary.copy(" ", count)
       end
     end


### PR DESCRIPTION
Elixir v1.5 isn't allowing private functions to be compiled.

```
==> html_builder
Compiling 1 file (.ex)

== Compilation error in file lib/html_builder/encoder.ex ==
** (CompileError) lib/html_builder/encoder.ex:91: inlined function pretty/1 undefined
    (stdlib) lists.erl:1338: :lists.foreach/2
    lib/html_builder/encoder.ex:91: (file)
could not compile dependency :html_builder, "mix compile" failed. You can recompile this dependency with "mix deps.compile html_builder", update it with "mix deps.update html_builder" or clean it with "mix deps.clean html_builder"
```

I couldn't find anything in the 1.5 changelog mentioning this, but it has no problems with public functions.